### PR TITLE
add a link to the kaspersky report about LogoFAIL

### DIFF
--- a/index.md
+++ b/index.md
@@ -25,4 +25,4 @@ Some rat creators are smart enough to hide it fully, in that case you would need
 
 ### thats not it?
 
-Some rats hide in uefi bioses. Mostly, you're screwed. Good luck getting out of this one.
+[Some rats hide in uefi bioses.](https://www.kaspersky.co.uk/blog/logofail-uefi-vulnerabilities/27098/) Mostly, you're screwed. Good luck getting out of this one.


### PR DESCRIPTION
this adds an example of an exploit that can allow malware to hide in your BIOS